### PR TITLE
Fix serializer & deserializer bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.2
+
+* `[FIX]` Fix serializer.
+  * Object member meta info format is wrong.
+  * Optional, ~~repeated, sequence, and spread~~ info is lost in named type case.
+
 ## v0.2.1
 
 * A grammar for referencing other interface members has been added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## v0.2.2
 
-* `[FIX]` Fix serializer.
+* `[FIX]` Fix serializer bugs.
   * Object member meta info format is wrong.
-  * Optional, ~~repeated, sequence, and spread~~ info is lost in named type case.
+  * Optional info is lost in named type case.
+  * Extended interface has unexpected duplicated member properties.
+* Add spec codes.
 
 ## v0.2.1
 

--- a/examples/schema/_compiled/fields.json
+++ b/examples/schema/_compiled/fields.json
@@ -140,8 +140,13 @@
           [
             "numberTypeField",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "NumberType",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "NumberType",
+                "typeName": "NumberType",
+                "name": "NumberType"
+              },
               "typeName": "NumberType",
               "name": "numberTypeField"
             }
@@ -457,8 +462,13 @@
           [
             "numberTypeField",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "NumberType",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "NumberType",
+                "typeName": "NumberType",
+                "name": "NumberType"
+              },
               "typeName": "NumberType",
               "name": "numberTypeField"
             }

--- a/examples/schema/_compiled/fields.ts
+++ b/examples/schema/_compiled/fields.ts
@@ -142,8 +142,13 @@ const schema = {
           [
             "numberTypeField",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "NumberType",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "NumberType",
+                "typeName": "NumberType",
+                "name": "NumberType"
+              },
               "typeName": "NumberType",
               "name": "numberTypeField"
             }
@@ -459,8 +464,13 @@ const schema = {
           [
             "numberTypeField",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "NumberType",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "NumberType",
+                "typeName": "NumberType",
+                "name": "NumberType"
+              },
               "typeName": "NumberType",
               "name": "numberTypeField"
             }

--- a/examples/schema/_compiled/tynder.json
+++ b/examples/schema/_compiled/tynder.json
@@ -570,8 +570,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             }
@@ -673,8 +678,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -790,8 +800,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -907,8 +922,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1198,8 +1218,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1495,8 +1520,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1662,8 +1692,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1830,8 +1865,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2004,8 +2044,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2136,8 +2181,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2262,8 +2312,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2417,8 +2472,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2756,8 +2816,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2881,8 +2946,13 @@
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -3073,8 +3143,13 @@
           [
             "errorMessages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "errorMessages"
             }
@@ -3217,8 +3292,13 @@
           [
             "schema",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "TypeAssertionMap",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "TypeAssertionMap",
+                "typeName": "TypeAssertionMap",
+                "name": "TypeAssertionMap"
+              },
               "typeName": "TypeAssertionMap",
               "name": "schema"
             }
@@ -3307,8 +3387,13 @@
           [
             "schema",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "TypeAssertionMap",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "TypeAssertionMap",
+                "typeName": "TypeAssertionMap",
+                "name": "TypeAssertionMap"
+              },
               "typeName": "TypeAssertionMap",
               "name": "schema"
             }

--- a/examples/schema/_compiled/tynder.ts
+++ b/examples/schema/_compiled/tynder.ts
@@ -572,8 +572,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             }
@@ -675,8 +680,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -792,8 +802,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -909,8 +924,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1200,8 +1220,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1497,8 +1522,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1664,8 +1694,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -1832,8 +1867,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2006,8 +2046,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2138,8 +2183,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2264,8 +2314,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2419,8 +2474,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2758,8 +2818,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -2883,8 +2948,13 @@ const schema = {
           [
             "messages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "messages"
             },
@@ -3075,8 +3145,13 @@ const schema = {
           [
             "errorMessages",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "ErrorMessages",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "ErrorMessages",
+                "typeName": "ErrorMessages",
+                "name": "ErrorMessages"
+              },
               "typeName": "ErrorMessages",
               "name": "errorMessages"
             }
@@ -3219,8 +3294,13 @@ const schema = {
           [
             "schema",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "TypeAssertionMap",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "TypeAssertionMap",
+                "typeName": "TypeAssertionMap",
+                "name": "TypeAssertionMap"
+              },
               "typeName": "TypeAssertionMap",
               "name": "schema"
             }
@@ -3309,8 +3389,13 @@ const schema = {
           [
             "schema",
             {
-              "kind": "symlink",
-              "symlinkTargetName": "TypeAssertionMap",
+              "kind": "optional",
+              "optional": {
+                "kind": "symlink",
+                "symlinkTargetName": "TypeAssertionMap",
+                "typeName": "TypeAssertionMap",
+                "name": "TypeAssertionMap"
+              },
               "typeName": "TypeAssertionMap",
               "name": "schema"
             }

--- a/src/_spec/compiler-1.spec.ts
+++ b/src/_spec/compiler-1.spec.ts
@@ -192,25 +192,27 @@ describe("compiler-1", function() {
                 kind: 'primitive-value',
                 value: 3,
             };
-            const ty = getType(schema, 'BarA');
-            expect(ty).toEqual(rhs);
-            expect(validate<number>(0, ty)).toEqual(null);
-            expect(validate<number>(1, ty)).toEqual(null);
-            expect(validate<number>(1.1, ty)).toEqual(null);
-            expect(validate<number>(BigInt(0), ty)).toEqual(null);
-            expect(validate<number>(BigInt(1), ty)).toEqual(null);
-            expect(validate<number>('', ty)).toEqual(null);
-            expect(validate<number>('1', ty)).toEqual(null);
-            expect(validate<number>(false, ty)).toEqual(null);
-            expect(validate<number>(true, ty)).toEqual(null);
-            expect(validate<number>(null, ty)).toEqual(null);
-            expect(validate<number>(void 0, ty)).toEqual(null);
-            expect(validate<number>({}, ty)).toEqual(null);
-            expect(validate<number>([], ty)).toEqual(null);
-            expect(validate<number>(3, ty)).toEqual({value: 3});
-            expect(validate<number>(BigInt(7), ty)).toEqual(null);
-            expect(validate<number>('XB', ty)).toEqual(null);
-            expect(validate<number>(true, ty)).toEqual(null);
+            // const ty = getType(schema, 'BarA');
+            for (const ty of [getType(deserialize(serialize(schema)), 'BarA'), getType(schema, 'BarA')]) {
+                expect(ty).toEqual(rhs);
+                expect(validate<number>(0, ty)).toEqual(null);
+                expect(validate<number>(1, ty)).toEqual(null);
+                expect(validate<number>(1.1, ty)).toEqual(null);
+                expect(validate<number>(BigInt(0), ty)).toEqual(null);
+                expect(validate<number>(BigInt(1), ty)).toEqual(null);
+                expect(validate<number>('', ty)).toEqual(null);
+                expect(validate<number>('1', ty)).toEqual(null);
+                expect(validate<number>(false, ty)).toEqual(null);
+                expect(validate<number>(true, ty)).toEqual(null);
+                expect(validate<number>(null, ty)).toEqual(null);
+                expect(validate<number>(void 0, ty)).toEqual(null);
+                expect(validate<number>({}, ty)).toEqual(null);
+                expect(validate<number>([], ty)).toEqual(null);
+                expect(validate<number>(3, ty)).toEqual({value: 3});
+                expect(validate<number>(BigInt(7), ty)).toEqual(null);
+                expect(validate<number>('XB', ty)).toEqual(null);
+                expect(validate<number>(true, ty)).toEqual(null);
+            }
         }
         {
             const rhs: TypeAssertion = {
@@ -219,25 +221,27 @@ describe("compiler-1", function() {
                 kind: 'primitive-value',
                 value: BigInt(7),
             };
-            const ty = getType(schema, 'BarB');
-            expect(ty).toEqual(rhs);
-            expect(validate<BigInt>(0, ty)).toEqual(null);
-            expect(validate<BigInt>(1, ty)).toEqual(null);
-            expect(validate<BigInt>(1.1, ty)).toEqual(null);
-            expect(validate<BigInt>(BigInt(0), ty)).toEqual(null);
-            expect(validate<BigInt>(BigInt(1), ty)).toEqual(null);
-            expect(validate<BigInt>('', ty)).toEqual(null);
-            expect(validate<BigInt>('1', ty)).toEqual(null);
-            expect(validate<BigInt>(false, ty)).toEqual(null);
-            expect(validate<BigInt>(true, ty)).toEqual(null);
-            expect(validate<BigInt>(null, ty)).toEqual(null);
-            expect(validate<BigInt>(void 0, ty)).toEqual(null);
-            expect(validate<BigInt>({}, ty)).toEqual(null);
-            expect(validate<BigInt>([], ty)).toEqual(null);
-            expect(validate<BigInt>(3, ty)).toEqual(null);
-            expect(validate<BigInt>(BigInt(7), ty)).toEqual({value: BigInt(7)});
-            expect(validate<BigInt>('XB', ty)).toEqual(null);
-            expect(validate<BigInt>(true, ty)).toEqual(null);
+            // const ty = getType(schema, 'BarB');
+            for (const ty of [getType(deserialize(serialize(schema)), 'BarB'), getType(schema, 'BarB')]) {
+                expect(ty).toEqual(rhs);
+                expect(validate<BigInt>(0, ty)).toEqual(null);
+                expect(validate<BigInt>(1, ty)).toEqual(null);
+                expect(validate<BigInt>(1.1, ty)).toEqual(null);
+                expect(validate<BigInt>(BigInt(0), ty)).toEqual(null);
+                expect(validate<BigInt>(BigInt(1), ty)).toEqual(null);
+                expect(validate<BigInt>('', ty)).toEqual(null);
+                expect(validate<BigInt>('1', ty)).toEqual(null);
+                expect(validate<BigInt>(false, ty)).toEqual(null);
+                expect(validate<BigInt>(true, ty)).toEqual(null);
+                expect(validate<BigInt>(null, ty)).toEqual(null);
+                expect(validate<BigInt>(void 0, ty)).toEqual(null);
+                expect(validate<BigInt>({}, ty)).toEqual(null);
+                expect(validate<BigInt>([], ty)).toEqual(null);
+                expect(validate<BigInt>(3, ty)).toEqual(null);
+                expect(validate<BigInt>(BigInt(7), ty)).toEqual({value: BigInt(7)});
+                expect(validate<BigInt>('XB', ty)).toEqual(null);
+                expect(validate<BigInt>(true, ty)).toEqual(null);
+            }
         }
         {
             const rhs: TypeAssertion = {
@@ -246,25 +250,27 @@ describe("compiler-1", function() {
                 kind: 'primitive-value',
                 value: 'XB',
             };
-            const ty = getType(schema, 'BarC');
-            expect(ty).toEqual(rhs);
-            expect(validate<string>(0, ty)).toEqual(null);
-            expect(validate<string>(1, ty)).toEqual(null);
-            expect(validate<string>(1.1, ty)).toEqual(null);
-            expect(validate<string>(BigInt(0), ty)).toEqual(null);
-            expect(validate<string>(BigInt(1), ty)).toEqual(null);
-            expect(validate<string>('', ty)).toEqual(null);
-            expect(validate<string>('1', ty)).toEqual(null);
-            expect(validate<string>(false, ty)).toEqual(null);
-            expect(validate<string>(true, ty)).toEqual(null);
-            expect(validate<string>(null, ty)).toEqual(null);
-            expect(validate<string>(void 0, ty)).toEqual(null);
-            expect(validate<string>({}, ty)).toEqual(null);
-            expect(validate<string>([], ty)).toEqual(null);
-            expect(validate<string>(3, ty)).toEqual(null);
-            expect(validate<string>(BigInt(7), ty)).toEqual(null);
-            expect(validate<string>('XB', ty)).toEqual({value: 'XB'});
-            expect(validate<string>(true, ty)).toEqual(null);
+            // const ty = getType(schema, 'BarC');
+            for (const ty of [getType(deserialize(serialize(schema)), 'BarC'), getType(schema, 'BarC')]) {
+                expect(ty).toEqual(rhs);
+                expect(validate<string>(0, ty)).toEqual(null);
+                expect(validate<string>(1, ty)).toEqual(null);
+                expect(validate<string>(1.1, ty)).toEqual(null);
+                expect(validate<string>(BigInt(0), ty)).toEqual(null);
+                expect(validate<string>(BigInt(1), ty)).toEqual(null);
+                expect(validate<string>('', ty)).toEqual(null);
+                expect(validate<string>('1', ty)).toEqual(null);
+                expect(validate<string>(false, ty)).toEqual(null);
+                expect(validate<string>(true, ty)).toEqual(null);
+                expect(validate<string>(null, ty)).toEqual(null);
+                expect(validate<string>(void 0, ty)).toEqual(null);
+                expect(validate<string>({}, ty)).toEqual(null);
+                expect(validate<string>([], ty)).toEqual(null);
+                expect(validate<string>(3, ty)).toEqual(null);
+                expect(validate<string>(BigInt(7), ty)).toEqual(null);
+                expect(validate<string>('XB', ty)).toEqual({value: 'XB'});
+                expect(validate<string>(true, ty)).toEqual(null);
+            }
         }
         {
             const rhs: TypeAssertion = {
@@ -273,25 +279,27 @@ describe("compiler-1", function() {
                 kind: 'primitive-value',
                 value: true,
             };
-            const ty = getType(schema, 'BarD');
-            expect(ty).toEqual(rhs);
-            expect(validate<boolean>(0, ty)).toEqual(null);
-            expect(validate<boolean>(1, ty)).toEqual(null);
-            expect(validate<boolean>(1.1, ty)).toEqual(null);
-            expect(validate<boolean>(BigInt(0), ty)).toEqual(null);
-            expect(validate<boolean>(BigInt(1), ty)).toEqual(null);
-            expect(validate<boolean>('', ty)).toEqual(null);
-            expect(validate<boolean>('1', ty)).toEqual(null);
-            expect(validate<boolean>(false, ty)).toEqual(null);
-            expect(validate<boolean>(true, ty)).toEqual({value: true});
-            expect(validate<boolean>(null, ty)).toEqual(null);
-            expect(validate<boolean>(void 0, ty)).toEqual(null);
-            expect(validate<boolean>({}, ty)).toEqual(null);
-            expect(validate<boolean>([], ty)).toEqual(null);
-            expect(validate<boolean>(3, ty)).toEqual(null);
-            expect(validate<boolean>(BigInt(7), ty)).toEqual(null);
-            expect(validate<boolean>('XB', ty)).toEqual(null);
-            expect(validate<boolean>(true, ty)).toEqual({value: true});
+            // const ty = getType(schema, 'BarD');
+            for (const ty of [getType(deserialize(serialize(schema)), 'BarD'), getType(schema, 'BarD')]) {
+                expect(ty).toEqual(rhs);
+                expect(validate<boolean>(0, ty)).toEqual(null);
+                expect(validate<boolean>(1, ty)).toEqual(null);
+                expect(validate<boolean>(1.1, ty)).toEqual(null);
+                expect(validate<boolean>(BigInt(0), ty)).toEqual(null);
+                expect(validate<boolean>(BigInt(1), ty)).toEqual(null);
+                expect(validate<boolean>('', ty)).toEqual(null);
+                expect(validate<boolean>('1', ty)).toEqual(null);
+                expect(validate<boolean>(false, ty)).toEqual(null);
+                expect(validate<boolean>(true, ty)).toEqual({value: true});
+                expect(validate<boolean>(null, ty)).toEqual(null);
+                expect(validate<boolean>(void 0, ty)).toEqual(null);
+                expect(validate<boolean>({}, ty)).toEqual(null);
+                expect(validate<boolean>([], ty)).toEqual(null);
+                expect(validate<boolean>(3, ty)).toEqual(null);
+                expect(validate<boolean>(BigInt(7), ty)).toEqual(null);
+                expect(validate<boolean>('XB', ty)).toEqual(null);
+                expect(validate<boolean>(true, ty)).toEqual({value: true});
+            }
         }
         for (const ty of [getType(deserialize(serialize(schema)), 'BazA'), getType(schema, 'BazA')]) {
             const rhs: TypeAssertion = {
@@ -365,31 +373,33 @@ describe("compiler-1", function() {
                         primitiveName: 'number',
                     },
                 };
-                const ty = getType(schema, 'FooA');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual({value: [0]});
-                expect(validate<any>([1.1], ty)).toEqual({value: [1.1]});
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual({value: [3]});
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'FooA');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooA'), getType(schema, 'FooA')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual({value: [0]});
+                    expect(validate<any>([1.1], ty)).toEqual({value: [1.1]});
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual({value: [3]});
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -403,31 +413,33 @@ describe("compiler-1", function() {
                         primitiveName: 'bigint',
                     },
                 };
-                const ty = getType(schema, 'FooB');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual({value: [BigInt(0)]});
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual({value: [BigInt(7)]});
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'FooB');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooB'), getType(schema, 'FooB')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual({value: [BigInt(0)]});
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual({value: [BigInt(7)]});
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -441,31 +453,33 @@ describe("compiler-1", function() {
                         primitiveName: 'string',
                     },
                 };
-                const ty = getType(schema, 'FooC');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual({value: ['']});
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual({value: ['XB']});
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'FooC');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooC'), getType(schema, 'FooC')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual({value: ['']});
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual({value: ['XB']});
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -479,31 +493,33 @@ describe("compiler-1", function() {
                         primitiveName: 'boolean',
                     },
                 };
-                const ty = getType(schema, 'FooD');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual({value: [false]});
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual({value: [true]});
+                // const ty = getType(schema, 'FooD');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooD'), getType(schema, 'FooD')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual({value: [false]});
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual({value: [true]});
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -517,31 +533,33 @@ describe("compiler-1", function() {
                         primitiveName: 'null',
                     },
                 };
-                const ty = getType(schema, 'FooE');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual({value: [null]});
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'FooE');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooE'), getType(schema, 'FooE')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual({value: [null]});
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -555,31 +573,33 @@ describe("compiler-1", function() {
                         primitiveName: 'undefined',
                     },
                 };
-                const ty = getType(schema, 'FooF');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual({value: [void 0]});
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'FooF');
+                for (const ty of [getType(deserialize(serialize(schema)), 'FooF'), getType(schema, 'FooF')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual({value: [void 0]});
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -593,31 +613,33 @@ describe("compiler-1", function() {
                         value: 3,
                     },
                 };
-                const ty = getType(schema, 'BarA');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual({value: [3]});
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'BarA');
+                for (const ty of [getType(deserialize(serialize(schema)), 'BarA'), getType(schema, 'BarA')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual({value: [3]});
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -631,31 +653,33 @@ describe("compiler-1", function() {
                         value: BigInt(7),
                     },
                 };
-                const ty = getType(schema, 'BarB');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual({value: [BigInt(7)]});
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'BarB');
+                for (const ty of [getType(deserialize(serialize(schema)), 'BarB'), getType(schema, 'BarB')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual({value: [BigInt(7)]});
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -669,31 +693,33 @@ describe("compiler-1", function() {
                         value: 'XB',
                     },
                 };
-                const ty = getType(schema, 'BarC');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual({value: ['XB']});
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'BarC');
+                for (const ty of [getType(deserialize(serialize(schema)), 'BarC'), getType(schema, 'BarC')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual({value: ['XB']});
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -707,31 +733,33 @@ describe("compiler-1", function() {
                         value: true,
                     },
                 };
-                const ty = getType(schema, 'BarD');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual(null);
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual(null);
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual({value: [true]});
+                // const ty = getType(schema, 'BarD');
+                for (const ty of [getType(deserialize(serialize(schema)), 'BarD'), getType(schema, 'BarD')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual(null);
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual({value: [true]});
+                }
             }
             {
                 const rhs: TypeAssertion = {
@@ -745,32 +773,34 @@ describe("compiler-1", function() {
                         primitiveName: 'integer',
                     },
                 };
-                const ty = getType(schema, 'BazA');
-                expect(ty).toEqual(rhs);
-                expect(validate<any>(0, ty)).toEqual(null);
-                expect(validate<any>(1, ty)).toEqual(null);
-                expect(validate<any>(1.1, ty)).toEqual(null);
-                expect(validate<any>(BigInt(0), ty)).toEqual(null);
-                expect(validate<any>(BigInt(1), ty)).toEqual(null);
-                expect(validate<any>('', ty)).toEqual(null);
-                expect(validate<any>('1', ty)).toEqual(null);
-                expect(validate<any>(false, ty)).toEqual(null);
-                expect(validate<any>(true, ty)).toEqual(null);
-                expect(validate<any>(null, ty)).toEqual(null);
-                expect(validate<any>(void 0, ty)).toEqual(null);
-                expect(validate<any>({}, ty)).toEqual(null);
-                expect(validate<any>([], ty)).toEqual({value: []});
-                expect(validate<any>([0], ty)).toEqual({value: [0]});
-                expect(validate<any>([1.1], ty)).toEqual(null);
-                expect(validate<any>([BigInt(0)], ty)).toEqual(null);
-                expect(validate<any>([''], ty)).toEqual(null);
-                expect(validate<any>([false], ty)).toEqual(null);
-                expect(validate<any>([null], ty)).toEqual(null);
-                expect(validate<any>([void 0], ty)).toEqual(null);
-                expect(validate<any>([3], ty)).toEqual({value: [3]});
-                expect(validate<any>([BigInt(7)], ty)).toEqual(null);
-                expect(validate<any>(['XB'], ty)).toEqual(null);
-                expect(validate<any>([true], ty)).toEqual(null);
+                // const ty = getType(schema, 'BazA');
+                for (const ty of [getType(deserialize(serialize(schema)), 'BazA'), getType(schema, 'BazA')]) {
+                    expect(ty).toEqual(rhs);
+                    expect(validate<any>(0, ty)).toEqual(null);
+                    expect(validate<any>(1, ty)).toEqual(null);
+                    expect(validate<any>(1.1, ty)).toEqual(null);
+                    expect(validate<any>(BigInt(0), ty)).toEqual(null);
+                    expect(validate<any>(BigInt(1), ty)).toEqual(null);
+                    expect(validate<any>('', ty)).toEqual(null);
+                    expect(validate<any>('1', ty)).toEqual(null);
+                    expect(validate<any>(false, ty)).toEqual(null);
+                    expect(validate<any>(true, ty)).toEqual(null);
+                    expect(validate<any>(null, ty)).toEqual(null);
+                    expect(validate<any>(void 0, ty)).toEqual(null);
+                    expect(validate<any>({}, ty)).toEqual(null);
+                    expect(validate<any>([], ty)).toEqual({value: []});
+                    expect(validate<any>([0], ty)).toEqual({value: [0]});
+                    expect(validate<any>([1.1], ty)).toEqual(null);
+                    expect(validate<any>([BigInt(0)], ty)).toEqual(null);
+                    expect(validate<any>([''], ty)).toEqual(null);
+                    expect(validate<any>([false], ty)).toEqual(null);
+                    expect(validate<any>([null], ty)).toEqual(null);
+                    expect(validate<any>([void 0], ty)).toEqual(null);
+                    expect(validate<any>([3], ty)).toEqual({value: [3]});
+                    expect(validate<any>([BigInt(7)], ty)).toEqual(null);
+                    expect(validate<any>(['XB'], ty)).toEqual(null);
+                    expect(validate<any>([true], ty)).toEqual(null);
+                }
             }
         }
     });

--- a/src/_spec/compiler-2.spec.ts
+++ b/src/_spec/compiler-2.spec.ts
@@ -78,228 +78,230 @@ describe("compiler-2", function() {
                     }],
                 ],
             };
-            const ty = getType(schema, 'Foo');
-            expect(ty).toEqual(rhs);
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual({value: v});
-            }
-            {
-                const v = {
-                    // a1
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    // a2
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    // a3
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    // a4
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    // a5
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    // a6
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    // a7
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    // a8
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: BigInt(99), // wrong
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: 99, // wrong
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 7, // wrong
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: '', // wrong
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: void 0, // wrong
-                    a6: void 0,
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: null, // wrong
-                    a7: '',
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: 99, // wrong
-                    a8: 5,
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
-            }
-            {
-                const v = {
-                    a1: 3,
-                    a2: BigInt(5),
-                    a3: 'C',
-                    a4: true,
-                    a5: null,
-                    a6: void 0,
-                    a7: '',
-                    a8: 5.5, // wrong
-                };
-                expect(validate<any>(v, ty)).toEqual(null);
+            // const ty = getType(schema, 'Foo');
+            for (const ty of [getType(deserialize(serialize(schema)), 'Foo'), getType(schema, 'Foo')]) {
+                expect(ty).toEqual(rhs);
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual({value: v});
+                }
+                {
+                    const v = {
+                        // a1
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        // a2
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        // a3
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        // a4
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        // a5
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        // a6
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        // a7
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        // a8
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: BigInt(99), // wrong
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: 99, // wrong
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 7, // wrong
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: '', // wrong
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: void 0, // wrong
+                        a6: void 0,
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: null, // wrong
+                        a7: '',
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: 99, // wrong
+                        a8: 5,
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
+                {
+                    const v = {
+                        a1: 3,
+                        a2: BigInt(5),
+                        a3: 'C',
+                        a4: true,
+                        a5: null,
+                        a6: void 0,
+                        a7: '',
+                        a8: 5.5, // wrong
+                    };
+                    expect(validate<any>(v, ty)).toEqual(null);
+                }
             }
         }
     });
@@ -460,24 +462,26 @@ describe("compiler-2", function() {
                         }],
                     ],
                 };
-                const ty = getType(schema, 'Foo');
-                expect(ty).toEqual(rhs);
-                {
-                    const v = {
-                        a1: 3,
-                        a2: BigInt(5),
-                        a3: 'C',
-                        a4: true,
-                        a5: null,
-                        a6: void 0,
-                        a7: '',
-                        a8: 5,
-                    };
-                    expect(validate<any>(v, ty)).toEqual({value: v});
-                }
-                {
-                    const v = {};
-                    expect(validate<any>(v, ty)).toEqual({value: v});
+                // const ty = getType(schema, 'Foo');
+                for (const ty of [getType(deserialize(serialize(schema)), 'Foo'), getType(schema, 'Foo')]) {
+                    expect(ty).toEqual(rhs);
+                    {
+                        const v = {
+                            a1: 3,
+                            a2: BigInt(5),
+                            a3: 'C',
+                            a4: true,
+                            a5: null,
+                            a6: void 0,
+                            a7: '',
+                            a8: 5,
+                        };
+                        expect(validate<any>(v, ty)).toEqual({value: v});
+                    }
+                    {
+                        const v = {};
+                        expect(validate<any>(v, ty)).toEqual({value: v});
+                    }
                 }
             }
         }
@@ -610,20 +614,22 @@ describe("compiler-2", function() {
                         ...tyR.members.map(x => [x[0], x[1], true]),
                     ],
                 };
-                const ty = getType(schema, 'Foo');
-                expect(ty).toEqual(rhs);
-                {
-                    const v = {
-                        a1: 3,
-                        a2: BigInt(5),
-                        a3: 'C',
-                        a4: true,
-                        a5: null,
-                        a6: void 0,
-                        a7: '',
-                        a8: 5,
-                    };
-                    expect(validate<any>(v, ty)).toEqual({value: v});
+                // const ty = getType(schema, 'Foo');
+                for (const ty of [/*getType(deserialize(serialize(schema)), 'Foo'),*/ getType(schema, 'Foo')]) {
+                    expect(ty).toEqual(rhs);
+                    {
+                        const v = {
+                            a1: 3,
+                            a2: BigInt(5),
+                            a3: 'C',
+                            a4: true,
+                            a5: null,
+                            a6: void 0,
+                            a7: '',
+                            a8: 5,
+                        };
+                        expect(validate<any>(v, ty)).toEqual({value: v});
+                    }
                 }
             }
         }
@@ -719,40 +725,44 @@ describe("compiler-2", function() {
                 ],
             };
             tyEntry.oneOf[1] = rhs;
-            const ty = getType(schema, 'Folder');
-            expect(ty).toEqual(rhs);
-            expect(getType(schema, 'Entry')).toEqual(tyEntry);
-            {
-                const v = {
-                    type: 'folder',
-                    name: '/',
-                    entries: [{
-                        type: 'file',
-                        name: 'a',
-                    }, {
+            for (const ty of [/*getType(deserialize(serialize(schema)), 'Entry'),*/ getType(schema, 'Entry')]) {
+                expect(ty).toEqual(tyEntry);
+            }
+            // const ty = getType(schema, 'Folder');
+            for (const ty of [/*getType(deserialize(serialize(schema)), 'Folder'),*/ getType(schema, 'Folder')]) {
+                expect(ty).toEqual(rhs);
+                {
+                    const v = {
                         type: 'folder',
-                        name: 'b',
+                        name: '/',
                         entries: [{
                             type: 'file',
-                            name: 'c',
+                            name: 'a',
+                        }, {
+                            type: 'folder',
+                            name: 'b',
+                            entries: [{
+                                type: 'file',
+                                name: 'c',
+                            }],
                         }],
-                    }],
-                };
-                try {
-                    validate<any>(v, ty);
-                    expect(0).toEqual(1);
-                } catch (e) {
-                    expect(e.message).toEqual('Unresolved symbol \'Entry\' is appeared.');
+                    };
+                    try {
+                        validate<any>(v, ty);
+                        expect(0).toEqual(1);
+                    } catch (e) {
+                        expect(e.message).toEqual('Unresolved symbol \'Entry\' is appeared.');
+                    }
+                    const ctx1: Partial<ValidationContext> = {};
+                    expect(() => validate<any>(v, ty, ctx1)).toThrow(); // unresolved symlink 'Entry'
+                    expect(ctx1.errors).toEqual([{
+                        code: 'InvalidDefinition',
+                        message: '"entries" of "Folder" type definition is invalid.',
+                        dataPath: 'Folder:entries.(0:repeated).Entry',
+                        constraints: {}
+                    }]);
+                    expect(validate<any>(v, ty, {schema})).toEqual({value: v});
                 }
-                const ctx1: Partial<ValidationContext> = {};
-                expect(() => validate<any>(v, ty, ctx1)).toThrow(); // unresolved symlink 'Entry'
-                expect(ctx1.errors).toEqual([{
-                    code: 'InvalidDefinition',
-                    message: '"entries" of "Folder" type definition is invalid.',
-                    dataPath: 'Folder:entries.(0:repeated).Entry',
-                    constraints: {}
-                }]);
-                expect(validate<any>(v, ty, {schema})).toEqual({value: v});
             }
         }
     });

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -69,7 +69,8 @@ function hasMetaInfo(ty: TypeAssertion) {
 function serializeInner(ty: TypeAssertion, nestLevel: number): TypeAssertion {
     if (0 < nestLevel && ty.typeName && !hasMetaInfo(ty)) {
         switch (ty.kind) {
-        case 'optional': case 'repeated': case 'sequence': case 'spread':
+        case 'optional':
+        // case 'repeated': case 'sequence': case 'spread':
             // nothing to do.
             break;
         default:

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -68,15 +68,21 @@ function hasMetaInfo(ty: TypeAssertion) {
 
 function serializeInner(ty: TypeAssertion, nestLevel: number): TypeAssertion {
     if (0 < nestLevel && ty.typeName && !hasMetaInfo(ty)) {
-        return ({
-            ...{
-                kind: 'symlink',
-                symlinkTargetName: ty.typeName,
-                typeName: ty.typeName,
-            },
-            ...(ty.name ? {name: ty.name} : {}),
-            ...(ty.docComment ? {docComment: ty.docComment} : {}),
-        });
+        switch (ty.kind) {
+        case 'optional': case 'repeated': case 'sequence': case 'spread':
+            // nothing to do.
+            break;
+        default:
+            return ({
+                ...{
+                    kind: 'symlink',
+                    symlinkTargetName: ty.typeName as string, // NOTE: type inference failed if the switch statement is exists.
+                    typeName: ty.typeName,
+                },
+                ...(ty.name ? {name: ty.name} : {}),
+                ...(ty.docComment ? {docComment: ty.docComment} : {}),
+            });
+        }
     }
 
     const ret: TypeAssertion = {...ty};
@@ -198,7 +204,7 @@ function deserializeInner(ty: TypeAssertion) {
         ret.optional = deserializeInner(ret.optional);
         break;
     case 'object':
-        ret.members = ret.members.map(x => [x[0], deserializeInner(x[1]), x.slice(2)]) as any;
+        ret.members = ret.members.map(x => [x[0], deserializeInner(x[1]), ...x.slice(2)]) as any;
         // NOTE: keep 'baseTypes' as 'symlink'.
         break;
     default:

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -234,7 +234,7 @@ export function deserializeFromObject(obj: any) {
         });
     }
 
-    return resolveSchema(schema);
+    return resolveSchema(schema, {isDeserialization: true});
 }
 
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -70,7 +70,6 @@ function serializeInner(ty: TypeAssertion, nestLevel: number): TypeAssertion {
     if (0 < nestLevel && ty.typeName && !hasMetaInfo(ty)) {
         switch (ty.kind) {
         case 'optional':
-        // case 'repeated': case 'sequence': case 'spread':
             // nothing to do.
             break;
         default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,12 @@ export interface SymbolResolverOperators {
     [propName: string]: (...args: Array<TypeAssertion | string>) => TypeAssertion;
 }
 
-export interface SymbolResolverContext {
+
+export interface ResolveSymbolOptions {
+    isDeserialization?: boolean;
+}
+
+export interface SymbolResolverContext extends ResolveSymbolOptions {
     nestLevel: number;
     symlinkStack: string[]; // For detecting recursive type
     operators?: SymbolResolverOperators; // TODO: Add it to resolve backref in type operator's operands


### PR DESCRIPTION
Fix serializer & deserializer bugs:
* Object member meta info format is wrong. (serializer)
* Optional info is lost in named type case. (serializer)
* Extended interface has unexpected duplicated member properties. (deserializer)