### PR TITLE
Add recordType decorator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.3.2 (planned)
 
 * Improve one-of assertion validation error message.
+* Add `@recordType` decorator.
+  * If the decorated member field of object is validated, the union type is determined.
 
 
 ## v0.3.1

--- a/README.md
+++ b/README.md
@@ -615,6 +615,21 @@ interface B {
 * `@forceCast`
     * Validate after forcibly casting to the assertion's type.
         * > **WARNING**: In the JSON schema output, this is stripped.
+* `@recordType`
+    * If the decorated member field of object is validated, the union type is determined.
+    ```ts
+    interface Foo {
+        @recordType kind: 'foo';
+        ...
+    }
+    interface Bar {
+        @recordType kind: 'bar';
+        ...
+    }
+    type FooBar = Foo | Bar;
+    // If data {kind: 'foo', ...} is passed,
+    // the union type will be determined as `Foo`.
+    ```
 * `@msg(messages: string | ErrorMessages)`
     * Set custom error message.
 * `@msgId(messageId: string)`

--- a/docs/playground/assets/script/playground2.js
+++ b/docs/playground/assets/script/playground2.js
@@ -32,12 +32,14 @@ interface EntryBase {
 /** File entry */
 interface File extends EntryBase {
     /** Entry type */
+    @recordType
     type: 'file';
 }
 
 /** Folder entry */
 interface Folder extends EntryBase {
     /** Entry type */
+    @recordType
     type: 'folder';
     /** Child entries */
     entries: Entry[];

--- a/src/_spec/compiler-2.spec.ts
+++ b/src/_spec/compiler-2.spec.ts
@@ -768,8 +768,8 @@ describe("compiler-2", function() {
                     expect(() => validate<any>(v, ty, ctx1)).toThrow(); // unresolved symlink 'Entry'
                     expect(ctx1.errors).toEqual([...(cnt === 0 ? [{
                         code: 'ValueUnmatched',
-                        message: '"File" of "Entry" value should be "file".',
-                        dataPath: 'Folder:entries.(1:repeated).Entry:File.type',
+                        message: '"type" of "File" value should be "file".',
+                        dataPath: 'Folder:entries.(1:repeated).Entry:File:type',
                         value: 'folder',
                         constraints: {},
                     }] : []), {
@@ -925,8 +925,8 @@ describe("compiler-2", function() {
                     expect(() => validate<any>(v, ty, ctx1)).toThrow(); // unresolved symlink 'Entry'
                     expect(ctx1.errors).toEqual([...(cnt === 0 ? [{
                         code: 'ValueUnmatched',
-                        message: '"File" of "Entry" value should be "file".',
-                        dataPath: 'Folder:entries.(1:sequence).Entry:File.type',
+                        message: '"type" of "File" value should be "file".',
+                        dataPath: 'Folder:entries.(1:sequence).Entry:File:type',
                         value: 'folder',
                         constraints: {},
                     }] : []), {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1170,6 +1170,8 @@ export function compile(s: string) {
             operators.withStereotype(stereotype)(ty),
         '@forceCast': () => (ty: TypeAssertion) =>
             operators.withForceCast()(ty),
+        '@recordType': () => (ty: TypeAssertion) =>
+            operators.withRecordType()(ty),
         '@msg': (messages: string | ErrorMessages) => (ty: TypeAssertion) =>
             operators.withMsg(messages)(ty),
         '@msgId': (messageId: string) => (ty: TypeAssertion) =>

--- a/src/lib/reporter.ts
+++ b/src/lib/reporter.ts
@@ -298,7 +298,11 @@ export function reportError(
                 } else {
                     const len = dataPathEntryArray.length;
                     if (len && dataPathEntryArray[len - 1].kind === 'type') {
-                        dataPathEntryArray.push({kind: 'key', name: pt.name});
+                        if (pt.kind === 'object' && next && pt.typeName) {
+                            dataPathEntryArray.push({kind: 'type', name: pt.typeName});
+                        } else {
+                            dataPathEntryArray.push({kind: 'key', name: pt.name as string}); // NOTE: type inference failed
+                        }
                     } else {
                         if (pt.typeName) {
                             dataPathEntryArray.push({kind: 'type', name: pt.typeName});

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -866,6 +866,17 @@ export function withForceCast<T extends TypeAssertion>(): (ty: T) => T {
 }
 
 
+export function withRecordType<T extends TypeAssertion>(): (ty: T) => T {
+    return (ty: T) => {
+        const ret: T = ({
+            ...ty,
+            isRecordTypeField: true,
+        });
+        return ret;
+    };
+}
+
+
 export function withMsg<T extends TypeAssertion>(messages: string | ErrorMessages): (ty: T) => T {
     return (ty: T) => {
         if (ty.kind === 'optional') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,9 +62,12 @@ export interface ValidationContext {
         TypeAssertion |
         [TypeAssertion,
          number | string | undefined] // [1]: data index
-        >;
-                                      // NOTE: DO NOT reassign!
+        >;                            // NOTE: DO NOT reassign!
                                       //   Push or pop items instead of reassign.
+
+    recordTypeFieldValidated?: boolean;
+
+    // === additional infos ===
     schema?: TypeAssertionMap;        //   To resolve 'symlink' assertion,
                                       //   the context need to have a schema instance.
 

--- a/src/types/tynder-schema-types.ts
+++ b/src/types/tynder-schema-types.ts
@@ -48,6 +48,7 @@ export interface TypeAssertionBase {
     originalTypeName?: string;  // To keep right hand side type name of `type Y = X;`.
     stereotype?: string;
     forceCast?: boolean;
+    isRecordTypeField?: boolean;
     docComment?: string;        // Doc comment.
     passThruCodeBlock?: string; // Store a pass-thru code block (e.g. import statement). use it with kind===never
     noOutput?: boolean;         // If true, skip code generation.


### PR DESCRIPTION
* Improve one-of assertion validation error message.
* Add `@recordType` decorator.
  * If the decorated member field of object is validated, the union type is determined.