### PR TITLE
Feature type guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.4.0
 
 * Add type guard functions `isType`.
+* `[FIX]` Fix `date`, `lcdate`, `datetime`, `lcdatetime` stereotypes.
+  * Constructor returns wrong month if passed month's day of month is shorted than current month.
 
 ### _Breaking changes_
 * Type of `ValidationError::ctx` is changed to `Partial<ValidationContext>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-* Add type guard functions `isType` and `shouldBeType`.
+* Add type guard functions `isType`.
 
 ### _Breaking changes_
 * Type of `ValidationError::ctx` is changed to `Partial<ValidationContext>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.4.0
+
+* Add type guard functions `isType` and `shouldBeType`.
+
+### _Breaking changes_
+* Type of `ValidationError::ctx` is changed to `Partial<ValidationContext>`.
+
+
+
 ## v0.3.11
 
 * `[FIX]` Fix d.ts code generation: empty objects generate invalid code.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ try {
 
 ### From object (import)
 ```ts
+...
 import { deserializeFromObject } from 'tynder/modules/lib/serializer';
 import { Foo, A }                from './path/to/schema-types/my-schema';    // type definitions (.d.ts)
 import mySchema_                 from './path/to/schema-compiled/my-schema'; // pre-compiled schema (.ts)
@@ -296,6 +297,7 @@ if (validated) {
 
 ### From object (require JSON file)
 ```ts
+...
 import { deserializeFromObject } from 'tynder/modules/lib/serializer';
 import { Foo, A }                from './path/to/schema-types/my-schema'; // type definitions (.d.ts)
 
@@ -316,6 +318,7 @@ if (validated) {
 ```
 or
 ```ts
+...
 import { deserializeFromObject } from 'tynder/modules/lib/serializer';
 import { Foo, A }                from './path/to/schema-types/my-schema';         // type definitions (.d.ts)
 import mySchemaJson              from './path/to/schema-compiled/my-schema.json'; // pre-compiled schema (.json)
@@ -334,6 +337,7 @@ if (validated) {
 
 ### From text
 ```ts
+...
 import { deserialize } from 'tynder/modules/lib/serializer';
 import { Foo, A }      from './path/to/schema-types/my-schema'; // type definitions (.d.ts)
 import * as fs         from 'fs';
@@ -381,6 +385,39 @@ try {
 } catch (e) {
     console.log(e.message);
     console.log(e.ctx?.errors);
+}
+```
+
+
+### Type guards
+
+```ts
+import { isType,
+         getType } from 'tynder/modules/validator';
+
+...
+
+const unknownInput: unknown = {a: 'x'};
+if (isType<A>(unknownInput, getType(mySchema, 'A'), ctx) && unknownInput.a.length > 0) {
+    console.log(`ok: ${unknownInput.a.length}`);
+} else {
+    console.log('ng');
+}
+```
+
+```ts
+import { shouldBeType,
+         getType } from 'tynder/modules/validator';
+
+...
+
+try {
+    const unknownInput: unknown = {a: 'x'};
+    if (shouldBeType<A>(unknownInput, getType(mySchema, 'A'), ctx)) {
+        console.log(`ok: ${unknownInput.a.length}`);
+    } // If the type do not match, an error is thrown.
+} catch (e) {
+    console.log('ng');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -405,22 +405,6 @@ if (isType<A>(unknownInput, getType(mySchema, 'A'), ctx) && unknownInput.a.lengt
 }
 ```
 
-```ts
-import { shouldBeType,
-         getType } from 'tynder/modules/validator';
-
-...
-
-try {
-    const unknownInput: unknown = {a: 'x'};
-    if (shouldBeType<A>(unknownInput, getType(mySchema, 'A'), ctx)) {
-        console.log(`ok: ${unknownInput.a.length}`);
-    } // If the type do not match, an error is thrown.
-} catch (e) {
-    console.log('ng');
-}
-```
-
 
 ## Define schema with functional API
 

--- a/src/_spec/fixes-4.spec.ts
+++ b/src/_spec/fixes-4.spec.ts
@@ -2,6 +2,7 @@
 import { TypeAssertion,
          ValidationContext } from '../types';
 import { validate,
+         isType,
          getType }           from '../validator';
 import { pick,
          patch }             from '../picker';
@@ -341,5 +342,38 @@ describe("fix-3", function() {
         exp = exp.replace(/\s+/g, ' ').trim();
 
         expect(dts).toEqual(exp);
-    })
+    });
+    it("type-guard-1", function() {
+        const schemas = [compile(`
+            interface O {
+                a: string;
+                b: number;
+            }
+        `)];
+        for (const schema of schemas) {
+            {
+                const rhs: TypeAssertion = {
+                    name: 'O',
+                    typeName: 'O',
+                    kind: 'object',
+                    members: [
+                        ['a', {
+                            name: 'a',
+                            kind: 'primitive',
+                            primitiveName: 'string',
+                        }],
+                        ['b', {
+                            name: 'b',
+                            kind: 'primitive',
+                            primitiveName: 'number',
+                        }],
+                    ],
+                };
+                const ty = getType(schema, 'O');
+                expect(ty).toEqual(rhs);
+                const unk = {a: 'qwerty', b: 0};
+                expect(isType<{a: string, b: number}>(unk, ty) && unk.a === 'qwerty').toEqual(true);
+            }
+        }
+    });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -10,8 +10,8 @@ import { TypeAssertion,
 
 export class ValidationError extends Error {
     public ty?: TypeAssertion;
-    public ctx?: ValidationContext;
-    public constructor(message: string, ty?: TypeAssertion, ctx?: ValidationContext) {
+    public ctx?: Partial<ValidationContext>;
+    public constructor(message: string, ty?: TypeAssertion, ctx?: Partial<ValidationContext>) {
         super(message);
         this.ty = ty;
         this.ctx = ctx;

--- a/src/stereotypes/date.ts
+++ b/src/stereotypes/date.ts
@@ -48,6 +48,8 @@ class UtcDate extends Date {
             return;
         }
 
+        this.setUTCDate(1);
+
         this.setUTCFullYear(year);
         this.setUTCMonth(typeof month === 'number' ? month : 0);
         this.setUTCDate(typeof date === 'number' ? date : 1);
@@ -122,6 +124,8 @@ class LcDate extends Date {
             }
             return;
         }
+
+        this.setDate(1);
 
         this.setFullYear(year);
         this.setMonth(typeof month === 'number' ? month : 0);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -852,17 +852,6 @@ export function isType<T>(
 }
 
 
-export function shouldBeType<T>(
-    data: any, ty: TypeAssertion, ctx?: Partial<ValidationContext>): data is T {
-
-    if (validate<T>(data, ty, ctx)) {
-        return true;
-    } else {
-        throw new ValidationError('Validation failed.', ty, ctx);
-    }
-}
-
-
 export function getType(schema: TypeAssertionMap, name: string): TypeAssertion {
     if (schema.has(name)) {
         return schema.get(name)?.ty as TypeAssertion;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -848,16 +848,14 @@ export function validate<T>(
 export function isType<T>(
     data: any, ty: TypeAssertion, ctx?: Partial<ValidationContext>): data is T {
 
-    const z = validate<T>(data, ty, ctx);
-    return (!!z);
+    return (!! validate<T>(data, ty, ctx));
 }
 
 
 export function shouldBeType<T>(
     data: any, ty: TypeAssertion, ctx?: Partial<ValidationContext>): data is T {
 
-    const z = validate<T>(data, ty, ctx);
-    if (z) {
+    if (validate<T>(data, ty, ctx)) {
         return true;
     } else {
         throw new ValidationError('Validation failed.', ty, ctx);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -845,6 +845,26 @@ export function validate<T>(
 }
 
 
+export function isType<T>(
+    data: any, ty: TypeAssertion, ctx?: Partial<ValidationContext>): data is T {
+
+    const z = validate<T>(data, ty, ctx);
+    return (!!z);
+}
+
+
+export function shouldBeType<T>(
+    data: any, ty: TypeAssertion, ctx?: Partial<ValidationContext>): data is T {
+
+    const z = validate<T>(data, ty, ctx);
+    if (z) {
+        return true;
+    } else {
+        throw new ValidationError('Validation failed.', ty, ctx);
+    }
+}
+
+
 export function getType(schema: TypeAssertionMap, name: string): TypeAssertion {
     if (schema.has(name)) {
         return schema.get(name)?.ty as TypeAssertion;


### PR DESCRIPTION
* Add type guard functions `isType`.
* `[FIX]` Fix `date`, `lcdate`, `datetime`, `lcdatetime` stereotypes.
  * Constructor returns wrong month if passed month's day of month is shorted than current month.

### _Breaking changes_
* Type of `ValidationError::ctx` is changed to `Partial<ValidationContext>`.